### PR TITLE
서비스 크롤링 기술을 업데이트

### DIFF
--- a/src/main/java/com/example/servicehub/service/impl/CustomServiceAdministerImpl.java
+++ b/src/main/java/com/example/servicehub/service/impl/CustomServiceAdministerImpl.java
@@ -34,7 +34,7 @@ public class CustomServiceAdministerImpl implements CustomServiceAdminister {
 
         ServiceMetaData serviceMetaData = metaDataCrawler.tryToGetMetaData(request.getServiceUrl());
 
-        String logoStoreName = logoManager.download(serviceMetaData.getUrl());
+        String logoStoreName = logoManager.download(serviceMetaData.getImage());
 
         Client client = clientRepository.findById(clientId).orElseThrow(IllegalStateException::new);
 

--- a/src/main/java/com/example/servicehub/service/impl/CustomServiceAdministerImpl.java
+++ b/src/main/java/com/example/servicehub/service/impl/CustomServiceAdministerImpl.java
@@ -34,7 +34,7 @@ public class CustomServiceAdministerImpl implements CustomServiceAdminister {
 
         ServiceMetaData serviceMetaData = metaDataCrawler.tryToGetMetaData(request.getServiceUrl());
 
-        String logoStoreName = logoManager.download(serviceMetaData.getImageUrl());
+        String logoStoreName = logoManager.download(serviceMetaData.getUrl());
 
         Client client = clientRepository.findById(clientId).orElseThrow(IllegalStateException::new);
 

--- a/src/main/java/com/example/servicehub/support/JsoupMetaDataCrawler.java
+++ b/src/main/java/com/example/servicehub/support/JsoupMetaDataCrawler.java
@@ -20,13 +20,15 @@ public class JsoupMetaDataCrawler implements MetaDataCrawler{
     private ServiceMetaData getMetaData(String serviceUrl) throws IOException {
         Elements elements = Jsoup
                 .connect(serviceUrl)
+                .userAgent("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.152 Safari/537.36")
                 .get()
                 .getElementsByTag("meta");
-        ServiceMetaData serviceMetaData = new ServiceMetaData();
+        ServiceMetaData serviceMetaData = new ServiceMetaData(serviceUrl);
         for (var element : elements) {
             serviceMetaData.setAttributeByProperty(element.attr("property"),element.attr("content"));
             serviceMetaData.setAttributeByName(element.attr("name"),element.attr("content"));
         }
+
         return serviceMetaData ;
     }
 

--- a/src/main/java/com/example/servicehub/support/JsoupMetaDataCrawler.java
+++ b/src/main/java/com/example/servicehub/support/JsoupMetaDataCrawler.java
@@ -20,7 +20,7 @@ public class JsoupMetaDataCrawler implements MetaDataCrawler{
     private ServiceMetaData getMetaData(String serviceUrl) throws IOException {
         Elements elements = Jsoup
                 .connect(serviceUrl)
-                .userAgent("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.152 Safari/537.36")
+                .userAgent("Mozilla/5.0")
                 .get()
                 .getElementsByTag("meta");
         ServiceMetaData serviceMetaData = new ServiceMetaData(serviceUrl);

--- a/src/main/java/com/example/servicehub/support/ServiceMetaData.java
+++ b/src/main/java/com/example/servicehub/support/ServiceMetaData.java
@@ -12,7 +12,7 @@ import lombok.ToString;
 @Getter
 public class ServiceMetaData {
 
-    private final String DEFAULT_LOGO_URL = ProjectUtils.getDomain() + "/file/logo/default.png";
+    private final String DEFAULT_LOGO_URL = "https://service-hub.org/file/logo/default.png";
     private final String DEFAULT = "default";
 
     private String siteName;
@@ -66,7 +66,8 @@ public class ServiceMetaData {
     }
 
     private void setImage(String image) {
-        if(this.image.equals(DEFAULT)) this.image = image;
+        if(!image.contains("http")) return;
+        if(this.image.equals(DEFAULT_LOGO_URL)) this.image = image;
     }
 
     private void setDescription(String description) {

--- a/src/main/java/com/example/servicehub/support/ServiceMetaData.java
+++ b/src/main/java/com/example/servicehub/support/ServiceMetaData.java
@@ -2,15 +2,18 @@ package com.example.servicehub.support;
 
 import com.example.servicehub.util.ProjectUtils;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @ToString
 @AllArgsConstructor
 @NoArgsConstructor
+@Getter
 public class ServiceMetaData {
 
-    private final String defaultLogoURI = "/file/logo/default.png";
+    private final String DEFAULT_LOGO_URL = ProjectUtils.getDomain() + "/file/logo/default.png";
+    private final String DEFAULT = "default";
 
     private String siteName;
     private String title;
@@ -18,70 +21,55 @@ public class ServiceMetaData {
     private String image;
     private String description;
 
+    public ServiceMetaData(String serviceUrl){
+        this.url = serviceUrl;
+        this.title = DEFAULT;
+        this.siteName = DEFAULT;
+        this.description = DEFAULT;
+        this.image = DEFAULT_LOGO_URL;
+    }
+
     public void setAttributeByProperty(String property, String content){
+        if(content == null) return ;
         switch (property){
-            case "og:site_name" : this.siteName = content;return;
-            case "og:title" : this.title = content;return;
-            case "og:url" : this.url = content;return;
-            case "og:image" : this.image = content;return;
-            case "og:description" : this.description = content;return;
+            case "og:site_name" : setSiteName(content); break;
+            case "og:title" : setTitle(content); break;
+            case "og:image" : setImage(content); break;
+            case "og:description" : setDescription(content); break;
         }
     }
 
     public void setAttributeByName(String name , String content){
+        if(content == null) return ;
         switch (name){
             case "site_name" :
-                if(this.siteName != null) return;
-                this.siteName = content;return;
+            case "twitter:site" :
+                setSiteName(content); break;
             case "title" :
-                if(this.title != null) return;
-                this.title = content;return;
-            case "url" :
-                if(this.url != null) return;
-                this.url = content;return;
+            case "twitter:title" :
+                setTitle(content); break;
             case "image" :
-                if(this.image != null) return;
-                this.image = content;return;
+            case "twitter:image" :
+                setImage(content); break;
             case "description" :
-                if(this.description != null) return;
-                this.description = content;
+            case "twitter:description" :
+                setDescription(content); break;
         }
     }
 
-    public String getSiteName() {
-        return getNullOrBlank(this.siteName);
+    private void setSiteName(String siteName) {
+        if(this.siteName.equals(DEFAULT)) this.siteName = siteName;
     }
 
-    public String getTitle() {
-        return getNullOrBlank(this.title);
+    private void setTitle(String title) {
+        if(this.title.equals(DEFAULT)) this.title = title;
     }
 
-    public String getUrl() {
-        return getNullOrBlank(this.url);
+    private void setImage(String image) {
+        if(this.image.equals(DEFAULT)) this.image = image;
     }
 
-
-    /**
-     * service 의 로고의 URL 이 있다면 반환하고 없다면 해당 서버의 Default Logo URL 을 반환한다.
-     * @return 로고 url
-     */
-
-    public String getImageUrl(){
-        if(isUrl(getNullOrBlank(this.image))) return this.image;
-        return ProjectUtils.getDomain() + defaultLogoURI;
-    }
-
-    public String getDescription() {
-        return getNullOrBlank(this.description);
-    }
-
-    private String getNullOrBlank(String str){
-        if(str == null) return "";
-        return str;
-    }
-
-    private boolean isUrl(String path){
-        if(path.contains("http"))return true;
-        return false;
+    private void setDescription(String description) {
+        if(this.description.equals(DEFAULT)) this.description = description;
     }
 }

--- a/src/main/java/com/example/servicehub/web/controller/ServiceController.java
+++ b/src/main/java/com/example/servicehub/web/controller/ServiceController.java
@@ -50,7 +50,7 @@ public class ServiceController {
                 serviceMetaData.getUrl(),
                 serviceMetaData.getTitle(),
                 serviceMetaData.getDescription(),
-                serviceMetaData.getImageUrl()
+                serviceMetaData.getImage()
         ));
 
         model.addAttribute("categories",categoryAdminister.getAllCategories());

--- a/src/test/java/com/example/servicehub/support/JsoupMetaDataCrawlerTest.java
+++ b/src/test/java/com/example/servicehub/support/JsoupMetaDataCrawlerTest.java
@@ -25,7 +25,7 @@ class JsoupMetaDataCrawlerTest {
 
         assertThatCode(() -> Jsoup
                 .connect("https://www.udemy.com/")
-                .userAgent("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.152 Safari/537.36")
+                .userAgent("Mozilla/5.0")
                 .get()
         ).doesNotThrowAnyException();
     }

--- a/src/test/java/com/example/servicehub/support/JsoupMetaDataCrawlerTest.java
+++ b/src/test/java/com/example/servicehub/support/JsoupMetaDataCrawlerTest.java
@@ -1,0 +1,60 @@
+package com.example.servicehub.support;
+
+import org.assertj.core.api.Assertions;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class JsoupMetaDataCrawlerTest {
+
+
+    JsoupMetaDataCrawler crawler = new JsoupMetaDataCrawler();
+
+    @Test
+    @DisplayName("crawler 연결 테스트 test")
+    public void serviceConnectTest() throws Exception{
+
+        assertThatCode(() -> Jsoup
+                .connect("https://www.udemy.com/")
+                .userAgent("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.152 Safari/537.36")
+                .get()
+        ).doesNotThrowAnyException();
+    }
+
+    @ParameterizedTest
+    @DisplayName("ServiceMetaData 테스트")
+    @MethodSource("crawlerTest")
+    public void getServiceMetaData(String serviceUrl ,String expectedServiceUrl , String title , String siteName) throws Exception{
+
+        ServiceMetaData serviceMetaData = crawler.tryToGetMetaData(serviceUrl);
+
+        assertThat(serviceMetaData.getUrl())
+                .isEqualTo(expectedServiceUrl);
+
+        assertThat(serviceMetaData.getTitle())
+                .isEqualTo(title);
+
+        assertThat(serviceMetaData.getSiteName())
+                .isEqualTo(siteName);
+
+    }
+
+
+    static Stream<Arguments> crawlerTest(){
+        return Stream.of(
+                Arguments.of("https://github.com/","https://github.com/","GitHub: Let’s build from here","@github"),
+                Arguments.of("https://www.inflearn.com/","https://www.inflearn.com/","인프런 - 미래의 동료들과 함께 성장하는 곳 | IT 정보 플랫폼","인프런"),
+                Arguments.of("https://papago.naver.com/","https://papago.naver.com/","Free translation service, Papago","Naver papago")
+        );
+    }
+
+}


### PR DESCRIPTION
- 로고 이미지를 가져올 수 있다면 다운로드해서 서버에 저장
- 가지고 올 수 없다면 default 이미지를 수정하고 수정 작업을 통해 로고를 변경한다.
- 파이썬 라이브러리까지 필요 없을 것 같다.
- 403 에러를 응답 받는 서비스에 대응하여 userAgent 를 설정해준다.