### PR TITLE
사용자 페이지에서 서비스 페이지 포워딩 기능 제거

### DIFF
--- a/src/main/resources/templates/client/client-page.html
+++ b/src/main/resources/templates/client/client-page.html
@@ -52,7 +52,7 @@
                                 <a class="card-link" style="display: block;width: 100%" th:href="@{/client/click/(serviceId=${service.serviceId},isCustom=${service.isCustom()})}">
                                     <img style="width: 50px; display: block" th:src="@{/file/logo/{logoStoreName} (logoStoreName=${service.logoStoreName})}" class="card-img" alt="image">
                                 </a>
-                                <a class="tile" th:text="${service.serviceName}"  th:href="@{/service/{serviceId} (serviceId=${service.serviceId})}">
+                                <a class="tile" th:text="${service.serviceName}">
                                 </a>
                         </div><!--//card-->
                 </div>


### PR DESCRIPTION
사용자 페이지에서 서비스 페이지 포워딩 기능 제거

- 사용자 경험에도 좋지 않고 굳이 필요없는 기능