### PR TITLE
fix : #85 - 커스텀 카테고리 동작 오류 해결

### DIFF
--- a/src/main/java/com/example/servicehub/service/impl/ClientServiceAdministerImpl.java
+++ b/src/main/java/com/example/servicehub/service/impl/ClientServiceAdministerImpl.java
@@ -80,19 +80,17 @@ public class ClientServiceAdministerImpl implements ClientServiceAdminister {
     @Override
     public List<ClickServiceDto> servicesOfClient(Long clientId, ServiceSearchConditionForm serviceSearchConditionForm) {
 
-        List<ClickServiceDto> servicesWithClick = searchCustomServicesFirstOrEmptyList(clientId,serviceSearchConditionForm);
+        List<ClickServiceDto> servicesWithClick = firstSearchCustomServices(clientId,serviceSearchConditionForm);
 
-        servicesWithClick.addAll(servicesRepository.searchByClient(clientId, serviceSearchConditionForm.getCategories(), serviceSearchConditionForm.getServiceName()));
+        List<ClickServiceDto> services = secondSearchServices(clientId, serviceSearchConditionForm);
 
-        for(var service : servicesWithClick){
-            service.setCategories(serviceCategoryRepository.findByServiceName(service.getServiceName()));
-        }
+        servicesWithClick.addAll(services);
 
         return servicesWithClick;
     }
 
 
-    private List<ClickServiceDto> searchCustomServicesFirstOrEmptyList(Long clientId , ServiceSearchConditionForm serviceSearchConditionForm){
+    private List<ClickServiceDto> firstSearchCustomServices(Long clientId , ServiceSearchConditionForm serviceSearchConditionForm){
         List<ClickServiceDto> servicesWithClick = new ArrayList<>();
 
         if(isCustomSearch(serviceSearchConditionForm.getCategories())){
@@ -103,6 +101,16 @@ public class ClientServiceAdministerImpl implements ClientServiceAdminister {
         }
 
         return servicesWithClick;
+    }
+
+    private List<ClickServiceDto> secondSearchServices(Long clientId, ServiceSearchConditionForm serviceSearchConditionForm){
+        List<ClickServiceDto> services = servicesRepository.searchByClient(clientId, serviceSearchConditionForm.getCategories(), serviceSearchConditionForm.getServiceName());
+
+        for(var service : services){
+            service.setCategories(serviceCategoryRepository.findByServiceName(service.getServiceName()));
+        }
+
+        return services;
     }
 
     private boolean isCustomSearch(List<String> categories){

--- a/src/test/java/com/example/servicehub/service/impl/ClientServiceAdministerImplTest.java
+++ b/src/test/java/com/example/servicehub/service/impl/ClientServiceAdministerImplTest.java
@@ -172,6 +172,22 @@ class ClientServiceAdministerImplTest {
                 .isEqualTo("test");
     }
 
+    @Test
+    @DisplayName("사용자 서비스 조회 - 카테고리")
+    public void givenClientAndServiceSearchCondition_whenSearchingCustomServiceFirstDefaultSortByClickNumber_thenSearchWithEachCategories() throws Exception{
+        // given
+        Client client = clientRepository.findById(1L).get();
+        ServiceSearchConditionForm serviceSearchConditionForm = ServiceSearchConditionForm.of(new ArrayList<>(List.of("CUSTOM")),null);
+        // when
+        addCustomService(client,"test");
+        List<ClickServiceDto> clickServiceDtos = clientServiceAdminister.servicesOfClient(client.getId(), serviceSearchConditionForm);
+        // then
+        assertThat(clickServiceDtos.size())
+                .isEqualTo(1);
+
+        assertThat(clickServiceDtos.get(0).getCategories())
+                .isEqualTo("CUSTOM");
+    }
 
 
     private void addCustomService(Client client,String serviceName){


### PR DESCRIPTION
Client-Page 에서 카테고리 조회 필터 기능이 동작하지 않는 이슈
[원인] 카테고리를 DB에서 가져와 따로 설정해주는 작업에서 먼저 가져온 커스텀 서비스의 카테고리를 오버라이드 함.
[해결] 오버라이드 하지 않게 불리