### PR TITLE
fix : 사용자 정보 수정시 발생한 오류 해결(#107)

### DIFF
--- a/src/main/java/com/example/servicehub/security/authentication/CustomerPrincipal.java
+++ b/src/main/java/com/example/servicehub/security/authentication/CustomerPrincipal.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.util.StringUtils;
 
 import java.security.Principal;
 import java.util.Collection;
@@ -83,6 +84,12 @@ public class CustomerPrincipal implements Principal, UserDetails {
         this.nickname = nickname;
     }
 
+    public void update(String nickname, String blogUrl, String introduceComment, String profileImageUrl) {
+        if (StringUtils.hasText(nickname)) this.nickname = nickname;
+        if (StringUtils.hasText(blogUrl)) this.blogUrl = blogUrl;
+        if (StringUtils.hasText(introduceComment)) this.introduceComment = introduceComment;
+        if (StringUtils.hasText(profileImageUrl)) this.profileImageUrl = profileImageUrl;
+    }
 
 }
 

--- a/src/main/java/com/example/servicehub/service/CustomerEditor.java
+++ b/src/main/java/com/example/servicehub/service/CustomerEditor.java
@@ -14,6 +14,8 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.Objects;
+
 @Component
 @RequiredArgsConstructor
 public class CustomerEditor {
@@ -38,8 +40,13 @@ public class CustomerEditor {
                 .blogUrl(customerEditForm.getBlogUrl())
                 .introduceComment(customerEditForm.getIntroComment())
                 .nickname(customerEditForm.getNickname())
-                .profileUrl(ProjectUtils.getDomain() + "/file/profile/" + storeName)
+                .profileUrl(getProfileUrl(storeName))
                 .build();
+    }
+
+    private String getProfileUrl(String storeName) {
+        if (Objects.equals(storeName, "default.png")) return null;
+        return ProjectUtils.getDomain() + "/file/profile/" + storeName;
     }
 
     private String getAccessToken() {
@@ -48,9 +55,10 @@ public class CustomerEditor {
 
     private void synchronization(CustomerEditRequest customerEditRequest) {
         CustomerPrincipal principal = (CustomerPrincipal) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        principal.setNickname(customerEditRequest.getNickname());
-        principal.setBlogUrl(customerEditRequest.getBlogUrl());
-        principal.setIntroduceComment(customerEditRequest.getIntroduceComment());
-        principal.setProfileImageUrl(customerEditRequest.getProfileUrl());
+        principal.update(
+                customerEditRequest.getNickname(),
+                customerEditRequest.getBlogUrl(),
+                customerEditRequest.getIntroduceComment(),
+                customerEditRequest.getProfileUrl());
     }
 }

--- a/src/test/java/com/example/servicehub/service/CustomerEditorTest.java
+++ b/src/test/java/com/example/servicehub/service/CustomerEditorTest.java
@@ -83,6 +83,7 @@ class CustomerEditorTest {
         Assertions.assertThat(principal.getNickname()).isEqualTo("hi");
         Assertions.assertThat(principal.getBlogUrl()).isEqualTo("https://impati.github.io");
         Assertions.assertThat(principal.getIntroduceComment()).isEqualTo("hello");
+        Assertions.assertThat(principal.getProfileImageUrl()).isEqualTo(getCustomerPrincipal().getProfileImageUrl());
     }
 
     private void createPrincipal() {


### PR DESCRIPTION
[원인] 사용자 정보 수정 시 첨부되지 않은 프로필 이미지가 있을 경우 default 파일로 저장되는 오류
[해결] 입력 값이 없을 때는 null 값을 보낸다.