### PR TITLE
bug : 서비스 요청 페이지로 접근할 방법을 버튼을 구현하여 해결(#115)

### DIFF
--- a/src/main/resources/templates/requested-service/articles.html
+++ b/src/main/resources/templates/requested-service/articles.html
@@ -20,6 +20,13 @@
     <section class="blog-list px-3 pr-0 p-md-5">
         <div class="container  single-col-max-width">
 
+
+            <div class="text-end">
+                <button class="btn btn-primary" th:onclick="|location.href='@{/requested-service/registration}'|">서비스
+                    요청
+                </button>
+            </div>
+
             <div class="table-responsive mt-5">
                 <table class="primary table table-striped">
                     <thead>

--- a/src/test/java/com/example/servicehub/support/JsoupMetaDataCrawlerTest.java
+++ b/src/test/java/com/example/servicehub/support/JsoupMetaDataCrawlerTest.java
@@ -2,7 +2,6 @@ package com.example.servicehub.support;
 
 import com.example.servicehub.support.crawl.JsoupMetaDataCrawler;
 import com.example.servicehub.support.crawl.ServiceMetaData;
-import org.jsoup.Jsoup;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -27,18 +26,6 @@ class JsoupMetaDataCrawlerTest {
                 Arguments.of("https://www.inflearn.com/", "https://www.inflearn.com/", "인프런 - 라이프타임 커리어 플랫폼", "인프런"),
                 Arguments.of("https://papago.naver.com/", "https://papago.naver.com/", "Free translation service, Papago", "Naver papago")
         );
-    }
-
-    @Test
-    @DisplayName("crawler 연결 테스트 test")
-    public void serviceConnectTest() throws Exception {
-
-        assertThatCode(() -> Jsoup
-                .connect("https://www.udemy.com")
-                .timeout(5000)
-                .userAgent("Opera")
-                .get()
-        ).doesNotThrowAnyException();
     }
 
     @ParameterizedTest


### PR DESCRIPTION
[원인] /request-service/registration 으로 서비스를 요청할 수 있는 기능을 구현했지만 접근할 방법이 직접 입력말고 없는 문제.
[해결] /request-service 페이지에서 /request-service/registration 페이지로 접근할 수 있는 버튼을 추가.